### PR TITLE
Add safe event.values length checking.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,13 @@
 
 # org.awokenwell.proximity
 
+This is a fork of https://github.com/rbarroetavena/cordova-plugin-proximity, which is a fork of https://github.com/awoken-well/cordova-plugin-proximity.
+It has been modified to improve power efficiency and be compatible with newer versions of Android.
+
 This plugin provides access to the device's (IR) proximity sensor. This sensor is typically used in applications to prevent touch events on the screen when the device is held close to one's face.
 
 ## Installation
-
+TODO: Change
     cordova plugin add https://github.com/awoken-well/cordova-plugin-proximity.git
 
 ## Supported Platforms
@@ -35,6 +38,8 @@ This plugin provides access to the device's (IR) proximity sensor. This sensor i
 - navigator.proximity.getProximityState
 - navigator.proximity.enableSensor
 - navigator.proximity.disableSensor
+- navigator.proximity.enableProximityScreenOff
+- navigator.proximity.disableProximityScreenOff
 
 ## navigator.proximity.getProximityState
 
@@ -47,7 +52,8 @@ This proximity state is returned to the 'successCallback' callback function.
 ## navigator.proximity.enableSensor
 
 Enable the proximity sensor. In iOS the proximity sensor is disabled by default and must
-be enabled manually.
+be enabled manually. If the proximity value is not checked within 30 seconds, the sensor
+will be turned off to save power.
 
     navigator.proximity.enableSensor();
 
@@ -56,6 +62,19 @@ be enabled manually.
 Disable the proximity sensor.
 
     navigator.proximity.disableSensor();
+
+## navigator.proximity.enableProximityScreenOff();
+
+This function enables the functionality that makes the device screen turn off when the proximity sensor detects a near object.
+Note that the device does not actually fall asleep while the screen is off.
+
+    navigator.proximity.enableProximityScreenOff();
+
+## navigator.proximity.disableProximityScreenOff();
+
+This function disables the functionality that makes the device screen turn off when the proximity sensor detects a near object.
+
+    navigator.proximity.disableProximityScreenOff();
 
 ### Example 1
 
@@ -117,7 +136,20 @@ This example shows a watcher. If other things approaches the phone, 'on_approch_
     // .... after testing
     //proximitysensorWatchStop(proximitysensor);
 
+### Example 3
 
-### iOS Quirks
+This example shows how the plugin can easily be used to turn the device screen on and off when
+it approaches an object.
 
-- iOS will automatically dim the screen and disable touch events when the proximity sensor is in the 'near' state. This can be circumvented by using undocumented API calls, but will result in App Store rejection.
+```
+// Enables polling of proximity to automatically disable screen when object is near
+startProximityPolling() {
+    navigator.proximity.enableSensor();
+    navigator.proximity.enableProximityScreenOff();
+}
+disable proximity sensing
+stopProximityPolling() {
+    navigator.proximity.disableProximityScreenOff();
+    navigator.proximity.disableSensor();
+}
+```

--- a/README.md
+++ b/README.md
@@ -25,8 +25,7 @@ It has been modified to improve power efficiency and be compatible with newer ve
 This plugin provides access to the device's (IR) proximity sensor. This sensor is typically used in applications to prevent touch events on the screen when the device is held close to one's face.
 
 ## Installation
-TODO: Change
-    cordova plugin add https://github.com/awoken-well/cordova-plugin-proximity.git
+    cordova plugin add https://github.com/opentelecom/cordova-plugin-proximity.git
 
 ## Supported Platforms
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -19,21 +19,27 @@
 
 # org.awokenwell.proximity
 
+This is a fork of https://github.com/rbarroetavena/cordova-plugin-proximity, which is a fork of https://github.com/awoken-well/cordova-plugin-proximity.
+It has been modified to improve power efficiency and be compatible with newer versions of Android.
+
 This plugin provides access to the device's (IR) proximity sensor. This sensor is typically used in applications to prevent touch events on the screen when the device is held close to one's face.
 
 ## Installation
-
+TODO: Change
     cordova plugin add https://github.com/awoken-well/cordova-plugin-proximity.git
 
 ## Supported Platforms
 
 - iOS
+- Android
 
 ## Methods
 
 - navigator.proximity.getProximityState
 - navigator.proximity.enableSensor
 - navigator.proximity.disableSensor
+- navigator.proximity.enableProximityScreenOff
+- navigator.proximity.disableProximityScreenOff
 
 ## navigator.proximity.getProximityState
 
@@ -46,7 +52,8 @@ This proximity state is returned to the 'successCallback' callback function.
 ## navigator.proximity.enableSensor
 
 Enable the proximity sensor. In iOS the proximity sensor is disabled by default and must
-be enabled manually.
+be enabled manually. If the proximity value is not checked within 30 seconds, the sensor
+will be turned off to save power.
 
     navigator.proximity.enableSensor();
 
@@ -54,20 +61,95 @@ be enabled manually.
 
 Disable the proximity sensor.
 
-    navigator.proximity.enableSensor();
+    navigator.proximity.disableSensor();
 
-### Example
+## navigator.proximity.enableProximityScreenOff();
+
+This function enables the functionality that makes the device screen turn off when the proximity sensor detects a near object.
+Note that the device does not actually fall asleep while the screen is off.
+
+    navigator.proximity.enableProximityScreenOff();
+
+## navigator.proximity.disableProximityScreenOff();
+
+This function disables the functionality that makes the device screen turn off when the proximity sensor detects a near object.
+
+    navigator.proximity.disableProximityScreenOff();
+
+### Example 1
 
     function onSuccess(state) {
-        alert('Proximity state: ' + state? 'near' : 'far');
+        alert('Proximity state: ' + (state ? 'near' : 'far'));
     };
 
     navigator.proximity.enableSensor();
     
     setInterval(function(){
-      navigator.getProximityState(onSuccess);
+      navigator.proximity.getProximityState(onSuccess);
     }, 1000);
 
-### iOS Quirks
 
-- iOS will automatically dim the screen and disable touch events when the proximity sensor is in the 'near' state. This can be circumvented by using undocumented API calls, but will result in App Store rejection.
+### Example 2
+
+This example shows a watcher. If other things approaches the phone, 'on_approch_callback' would be called. 
+
+
+    var proximitysensor = {
+    };
+
+    var proximitysensorWatchStart = function(_scope, on_approch_callback) {
+        if(navigator.proximity == null)
+            console.log("cannot find navigator.proximity");
+
+        navigator.proximity.enableSensor();
+
+        // Start watch timer to get proximity sensor value
+        var frequency = 100;
+        _scope.id = window.setInterval(function() {
+            navigator.proximity.getProximityState(function(val) { // on success
+                var timestamp = new Date().getTime();
+                if(timestamp - _scope.lastemittedtimestamp > 1000) { // test on each 1 secs
+                    if( proximitysensor.lastval == 1 && val == 0 ) { // far => near changed
+                        _scope.lastemittedtimestamp = timestamp;
+                        _scope.lastval = val;
+                        on_approch_callback(timestamp);
+                    }
+                }
+                _scope.lastval = val;
+            });
+        }, frequency);
+    }
+
+    var proximitysensorWatchStop = function(_scope) {
+        if(navigator.proximity == null)
+            console.log("cannot find navigator.proximity");
+
+        window.clearInterval( _scope.id );
+
+        navigator.proximity.disableSensor();
+    };
+
+    proximitysensorWatchStart(proximitysensor, function(timestamp) {
+       console.log('approched on ' + timestamp);
+    });
+
+    // .... after testing
+    //proximitysensorWatchStop(proximitysensor);
+
+### Example 3
+
+This example shows how the plugin can easily be used to turn the device screen on and off when
+it approaches an object.
+
+```
+// Enables polling of proximity to automatically disable screen when object is near
+startProximityPolling() {
+    navigator.proximity.enableSensor();
+    navigator.proximity.enableProximityScreenOff();
+}
+disable proximity sensing
+stopProximityPolling() {
+    navigator.proximity.disableProximityScreenOff();
+    navigator.proximity.disableSensor();
+}
+```

--- a/doc/index.md
+++ b/doc/index.md
@@ -25,8 +25,7 @@ It has been modified to improve power efficiency and be compatible with newer ve
 This plugin provides access to the device's (IR) proximity sensor. This sensor is typically used in applications to prevent touch events on the screen when the device is held close to one's face.
 
 ## Installation
-TODO: Change
-    cordova plugin add https://github.com/awoken-well/cordova-plugin-proximity.git
+    cordova plugin add https://github.com/opentelecom/cordova-plugin-proximity.git
 
 ## Supported Platforms
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "cordova-plugin-proximity-sensor",
+  "version": "1.0.0",
+  "description": "This plugin provides access to the device's (IR) proximity sensor. This sensor is typically used in applications to prevent touch events on the screen when the device is held close to one's face. It has been optimised to save power",
+  "main": "www/proximity.js",
+  "directories": {
+      "doc": "doc"
+    },
+  "scripts": {
+      "test": "echo \"Error: no test specified\" && exit 1"
+    },
+  "repository": {
+      "type": "git",
+      "url": "git+https://github.com/opentelecom/cordova-plugin-proximity.git"
+    },
+  "keywords": [
+      "cordova",
+      "proximity",
+      "plugin",
+      "android",
+      "ios"
+    ],
+  "author": "Olaf T.A. Janssen <o.t.a.janssen@gmail.com> (http://nullelement.org/)",
+  "license": "ISC",
+  "bugs": {
+      "url": "https://github.com/opentelecom/cordova-plugin-proximity/issues"
+    },
+  "homepage": "https://github.com/opentelecom/cordova-plugin-proximity#readme"
+}

--- a/plugin.xml
+++ b/plugin.xml
@@ -19,15 +19,15 @@
 -->
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
-           id="org.awokenwell.proximity"
+           id="org.opentelecom.proximity"
       version="0.2.1">
 	
     <name>Proximity Sensor</name>
     <description>Cordova Proximity Sensor Plugin</description>
     <license>Apache 2.0</license>
     <keywords>cordova,proximity,sensor</keywords>
-    <repo>https://github.com/awoken-well/cordova-plugin-proximity.git</repo>
-    <issue>https://github.com/awoken-well/cordova-plugin-proximity/issues</issue>
+    <repo>https://github.com/opentelecom/cordova-plugin-proximity.git</repo>
+    <issue>https://github.com/opentelecom/cordova-plugin-proximity/issues</issue>
 
     <js-module src="www/proximity.js" name="proximity">
         <clobbers target="navigator.proximity" />

--- a/src/android/ProximitySensorListener.java
+++ b/src/android/ProximitySensorListener.java
@@ -52,7 +52,9 @@ public class ProximitySensorListener extends CordovaPlugin implements SensorEven
     public static int STARTING = 1;
     public static int RUNNING = 2;
     public static int ERROR_FAILED_TO_START = 3;
-	
+
+    private static final String LOG_TAG = "ProximitySensorListener";
+
     // sensor result 
     public static int NEAR = 1;
     public static int FAR = 0;
@@ -100,9 +102,9 @@ public class ProximitySensorListener extends CordovaPlugin implements SensorEven
      * Executes the request and returns PluginResult.
      *
      * @param action                The action to execute.
-     * @param args          	    JSONArry of arguments for the plugin.
-     * @param callbackS=Context     The callback id used when calling back into JavaScript.
-     * @return              	    True if the action was valid.
+     * @param args                  JSONArry of arguments for the plugin.
+     * @param callbackContext       The callback id used when calling back into JavaScript.
+     * @return                      True if the action was valid.
      * @throws JSONException 
      */
     public boolean execute(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
@@ -170,27 +172,10 @@ public class ProximitySensorListener extends CordovaPlugin implements SensorEven
             return this.status;
         }
 
-        // Get proximity sensor from sensor manager
-        //@SuppressWarnings("deprecation")
-        //List<Sensor> list = this.sensorManager.getSensorList(Sensor.TYPE_PROXIMITY);
-
         this.mSensor = sensorManager.getDefaultSensor(Sensor.TYPE_PROXIMITY);
         sensorManager.registerListener(this, this.mSensor, SensorManager.SENSOR_DELAY_NORMAL);
         this.lastAccessTime = System.currentTimeMillis();
         this.setStatus(ProximitySensorListener.STARTING);
-
-//        // If found, then register as listener
-//        if (list != null && list.size() > 0) {
-//            this.mSensor = list.get(0);
-//            this.sensorManager.registerListener(this, this.mSensor, SensorManager.SENSOR_DELAY_NORMAL);
-//            this.lastAccessTime = System.currentTimeMillis();
-//            this.setStatus(ProximitySensorListener.STARTING);
-//        }
-//
-//        // If error, then set status to error
-//        else {
-//            this.setStatus(ProximitySensorListener.ERROR_FAILED_TO_START);
-//        }
 
         return this.status;
     }
@@ -206,7 +191,7 @@ public class ProximitySensorListener extends CordovaPlugin implements SensorEven
     }
 
     public void onAccuracyChanged(Sensor sensor, int accuracy) {
-        // TODO Auto-generated method stub
+        return;
     }
 
     /**
@@ -224,14 +209,22 @@ public class ProximitySensorListener extends CordovaPlugin implements SensorEven
     /**
      * Sensor listener event.
      *
-     * @param SensorEvent event
+     * @param event The proximity Sensor Event.
      */
     public void onSensorChanged(SensorEvent event) {
 
         int proximity;
 
-        Log.d("ProximitySensorListener", "XXX onSensorChanged sensor length -> " + event.values.length);
-        Log.d("ProximitySensorListener", "XXX onSensorChanged [0]-> " + event.values[0] + " [1]-> " + event.values[1] + " [2]-> " + event.values[2]);
+        Log.d(ProximitySensorListener.LOG_TAG, "XXX onSensorChanged sensor length -> " + event.values.length);
+
+        if(event.values.length < 1) {
+            Log.e(ProximitySensorListener.LOG_TAG, "XXX Proximity SensorEvent contained no values");
+            return;
+        }
+
+        for(int i = 0; i < event.values.length; i++) {
+            Log.d(ProximitySensorListener.LOG_TAG, "XXX onSensorChanged [" + i + "]-> " + event.values[i]);
+        }
 
         if (event.values[0] == 0) {
             proximity = ProximitySensorListener.NEAR;
@@ -244,7 +237,7 @@ public class ProximitySensorListener extends CordovaPlugin implements SensorEven
         this.proximity = proximity;
         this.setStatus(ProximitySensorListener.RUNNING);
 
-        // If proximity hasn't been read for TIMEOUT time, then turn off sensor to save power 
+        // If proximity hasn't been read for TIMEOUT time, then turn off sensor to save power
         if ((this.timeStamp - this.lastAccessTime) > this.TIMEOUT) {
             this.stop();
         }
@@ -260,9 +253,9 @@ public class ProximitySensorListener extends CordovaPlugin implements SensorEven
     }
 
     /**
-     * Get the most recent distance. 
+     * Get the most recent distance.
      *
-     * @return          distance 
+     * @return          distance
      */
     public int getProximity() {
         this.lastAccessTime = System.currentTimeMillis();
@@ -299,7 +292,7 @@ public class ProximitySensorListener extends CordovaPlugin implements SensorEven
      *
      */
     public void enableProximityScreenOff() {
-        Log.d("ProximitySensorListener", "XXX enableProximityScreenOff");
+        Log.d(ProximitySensorListener.LOG_TAG, "XXX enableProximityScreenOff");
         if(wakeLock != null) {
             wakeLock.release();
         }


### PR DESCRIPTION
Hi,

I was using this plugin and it crashes the app in Android Oreo. This was due to an ArrayIndexOutOfBounds exception when logging event.values[1] and event.values[2] as they are not present for proximity sensor events in this version of the API. I've modified the log statement to only log as many elements as there are in the array as well as removed some commented code and fixed some incorrect javadoc.

I've tested this and it works for Android 8.0 as well as Android 7.1.1